### PR TITLE
Run unit tests on all supported Python versions (3.9-3.14)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,8 +7,64 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  test_python_3_9:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coveralls
+
+    - name: Unit test
+      run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py
+
+  test_python_3_10:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coveralls
+
+    - name: Unit test
+      run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py
+
+  test_python_3_11:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coveralls
+
+    - name: Unit test
+      run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py
+
+  test_python_3_12:
     runs-on: ubuntu-latest
     steps:
     - name: GitHub Checkout
@@ -27,10 +83,48 @@ jobs:
     - name: Unit test
       run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py
 
-    - name: "Upload coverage to Codecov"
+  test_python_3_13:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.13"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coveralls
+
+    - name: Unit test
+      run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py
+
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         name: codecov-umbrella
         verbose: true
 
+  test_python_3_14:
+    runs-on: ubuntu-latest
+    steps:
+    - name: GitHub Checkout
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.14"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coveralls
+
+    - name: Unit test
+      run: coverage run --source unicorn_binance_trailing_stop_loss unittest_binance_trailing_stop_loss.py


### PR DESCRIPTION
## Summary
- Run unit tests on Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
- Separate job per version (same structure as UBLDC, UBRA, UBWA)
- Codecov upload on 3.13

## Test plan
- [ ] All 6 Python version jobs pass in CI