### PR TITLE
Remove Gitter references

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,6 @@
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/)
 [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://medium.lucit.tech)
 [![Telegram](https://img.shields.io/badge/chat-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://badges.gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss.svg)](https://gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![LUCIT-UBTSL-Banner](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/logo/LUCIT-UBTSL-Banner-Readme.png)](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html)
 

--- a/dev/sphinx/source/cli.md
+++ b/dev/sphinx/source/cli.md
@@ -18,7 +18,6 @@
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/)
 [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://medium.lucit.tech)
 [![Telegram](https://img.shields.io/badge/chat-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://badges.gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss.svg)](https://gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![LUCIT-UBTSL-Banner](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/logo/LUCIT-UBTSL-Banner-Readme.png)](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html)
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -71,8 +71,6 @@ about:
     [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/)
     [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://medium.lucit.tech)
     [![Telegram](https://img.shields.io/badge/chat-telegram-41ab8c)](https://t.me/unicorndevs)
-    [![Gitter](https://badges.gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss.svg)](https://gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-    
     [![LUCIT-UBTSL-Banner](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/logo/LUCIT-UBTSL-Banner-Readme.png)](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html)
     
     # UNICORN Binance Trailing Stop Loss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-trailing-s
 'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/LICENSE'
 'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues'
 'Telegram' = 'https://t.me/unicorndevs'
-'Chat' = 'https://app.gitter.im/#/room/#unicorn-binance-trailing-stop-loss:gitter.im'
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'Changes': 'https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/changelog.html',
         'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/LICENSE',
         'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues',
-        'Chat': 'https://gitter.im/unicorn-binance-suite/unicorn-binance-trailing-stop-loss',
         'Telegram': 'https://t.me/unicorndevs',
      },
      python_requires='>=3.9.0',


### PR DESCRIPTION
## Summary
- Remove all Gitter badge lines and chat URLs from `cli/README.md`, `meta.yaml`, `pyproject.toml`, `setup.py`, and `dev/sphinx/source/cli.md`
- Gitter service is dead, these references are no longer useful

## Test plan
- [ ] Verify no broken badge links remain
- [ ] Confirm PyPI/Conda metadata renders correctly without the Chat URL