### PR TITLE
Clean up READMEs: replace lucit.tech URLs, rewrite cli/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/unit-tests.yml)
 [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_wheels.yml)
 [![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_conda.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/)
 [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://technopathy.club)
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
@@ -22,10 +22,10 @@
 [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
 [Contributing](#contributing) | [Disclaimer](#disclaimer)
 
-A Python library with a [command line interface](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/cli.html) for a trailing stop loss and 
+A Python library with a [command line interface](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html) for a trailing stop loss and 
 smart entry on the Binance exchange.
 
-Please read carefully all provided [documentation](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/), our
+Please read carefully all provided [documentation](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/), our
 [disclaimer](#disclaimer) and look in the 
 [issues](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues) about known 
 problems before using this tool - ***you use it at your own risk!***
@@ -80,18 +80,18 @@ ubtsl.stop_manager()
 ```
 
 
-[Discover more possibilities](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/unicorn_binance_trailing_stop_loss.html).
+[Discover more possibilities](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/unicorn_binance_trailing_stop_loss.html).
 
 ## Start the engine on the command line (Windows, Linux and Mac):
 ```sh
 $ ubtsl --profile BTCUSDT_SELL --stoplosslimit 0.5%
 ```
 
-Read about the [CLI usage](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/cli.html).
+Read about the [CLI usage](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html).
 
 ## Description
 The Python package [UNICORN Binance Trailing Stop Loss](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss) 
-provides a reuseable library and [CLI interface](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/cli.html).
+provides a reuseable library and [CLI interface](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html).
 
 After starting the engine, a stop/loss order is placed on Binance and trailed until it is completely fulfilled. If desired, a 
 notification can be sent via email and Telegram afterward. Then it calls the function 
@@ -233,12 +233,12 @@ or the [current master branch](https://github.com/oliver-zehentleitner/unicorn-b
 - ./setup.py
 
 ## Change Log
-[https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/CHANGELOG.html](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/CHANGELOG.html)
+[https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/CHANGELOG.html](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/CHANGELOG.html)
 
 ## Documentation
-- [General](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech)
-- [Modules](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/modules.html)
-- [CLI](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/cli.html)
+- [General](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss)
+- [Modules](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/modules.html)
+- [CLI](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html)
 
 ## Examples
 - [example_logging.py](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/example_logging.py)
@@ -260,7 +260,7 @@ To receive notifications on available updates you can
 the repository on [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss), write your 
 [own script](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/example_version_of_this_package.py) 
 with using 
-[`is_update_available()`](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/unicorn_binance_trailing_stop_loss.html#unicorn_binance_trailing_stop_loss.manager.BinanceWebSocketApiManager.is_update_availabe).
+[`is_update_available()`](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/unicorn_binance_trailing_stop_loss.html#unicorn_binance_trailing_stop_loss.manager.BinanceWebSocketApiManager.is_update_availabe).
 
 To receive news (like inspection windows/maintenance) about the Binance API`s subscribe to their telegram groups: 
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,64 +1,43 @@
-[![Get a UNICORN Binance Suite License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/LUCIT-UBS-License-Offer.png)](https://shop.lucit.services)
-
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss)
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-trailing-stop-loss.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/releases)
-[![Anaconda Release](https://anaconda.org/lucit/unicorn-binance-trailing-stop-loss/badges/version.svg)](https://anaconda.org/lucit/unicorn-binance-trailing-stop-loss)
-[![Anaconda Downloads](https://anaconda.org/lucit/unicorn-binance-trailing-stop-loss/badges/downloads.svg)](https://anaconda.org/lucit/unicorn-binance-trailing-stop-loss)
 [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-trailing-stop-loss?color=blue)](https://pypi.org/project/unicorn-binance-trailing-stop-loss/)
-[![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-trailing-stop-loss)](https://pepy.tech/project/unicorn-binance-trailing-stop-loss)
 [![License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/LICENSE)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_trailing_stop_loss.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_trailing_stop_loss.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues)
-[![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-trailing-stop-loss)
-[![CodeQL](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/codeql-analysis.yml)
 [![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/unit-tests.yml)
-[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_wheels.yml)
-[![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/actions/workflows/build_conda.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/)
-[![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://medium.lucit.tech)
-[![Telegram](https://img.shields.io/badge/chat-telegram-41ab8c)](https://t.me/unicorndevs)
-
-[![LUCIT-UBTSL-Banner](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/logo/LUCIT-UBTSL-Banner-Readme.png)](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/)
+[![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 
 # UNICORN Binance Trailing Stop Loss CLI
 
-[Description](#description) | [Installation](#installation) | [Usage](#usage) | 
-[Example commands](#example-commands) | [Smart Entry](#smart-entry) | [Example files](#example-files) | 
-[Change Log](#change-log) | [Wiki](#wiki) | [Social](#social) |
-[Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
-[Contributing](#contributing) | [Leave a review](#you-want-to-say-thank-you) | [Disclaimer](#disclaimer) | [Commercial Support](#commercial-support)
+[Description](#description) | [Installation](#installation) | [Usage](#usage) |
+[Example commands](#example-commands) | [Smart Entry](#smart-entry) | [Example files](#example-files) |
+[Documentation](#documentation) | [Disclaimer](#disclaimer)
 
-After starting the engine, a stop/loss order is placed and trailed until it is completely fulfilled. If desired, a 
-notification can be sent via email and Telegram afterwards.
+After starting the engine, a stop/loss order is placed and trailed until it is completely fulfilled. If desired, a
+notification can be sent via email afterwards.
 
-In addition, there is a [smart entry](https://www.lucit.tech/ubtsl-cli.html#smart-entry) option called 
-`jump-in-and-trail`. This offers the possibility to buy spot, future and margin assets with a limit or market order and 
-then to trail a stop/loss order until sold.
+In addition, there is a smart entry option called `jump-in-and-trail`. This offers the possibility to buy spot, 
+future and margin assets with a limit or market order and then to trail a stop/loss order until sold.
 
-The CLI interface `ubtsl`/`ubtsl.exe` is installed during the 
-[installation of `unicorn-binance-trailing-stop-loss`](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html#installation-and-upgrade) 
-with `pip` or `conda` and is used to interact with the [`unicorn-binance-trailing-stop-loss`](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html) Python library.
+The CLI interface `ubtsl` is installed during the
+[installation of `unicorn-binance-trailing-stop-loss`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss#installation-and-upgrade)
+with `pip` and is used to interact with the
+[`unicorn-binance-trailing-stop-loss`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss) Python library.
 
-Please read carefully all provided [documentation](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/), our
-[disclaimer](#disclaimer) and look in the 
-[issues](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues) about known 
+Please read carefully all provided [documentation](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/), our
+[disclaimer](#disclaimer) and look in the
+[issues](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues) about known
 problems before using this tool - ***you use it at your own risk!***
 
 If you put this engine on a market, you should stop trading manually on this market yourself!
 
-Part of '[UNICORN Binance Suite](https://www.lucit.tech/unicorn-binance-suite.html)'.
-
-## Get a UNICORN Binance Suite License
-
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://medium.lucit.tech/how-to-obtain-and-use-a-unicorn-binance-suite-license-key-and-run-the-ubs-module-according-to-best-87b0088124a8#4ca4)!
+Part of '[UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite)'.
 
 ## Description
-After startup `ubtsl` tries to load a 
-[`ubtsl_config.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini) 
-and a 
-[`ubtsl_profiles.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini) 
-file from the `{home}/.lucit/` and the current working directory. Alternatively, you can specify these files explicitly with the 
+After startup `ubtsl` tries to load a
+[`ubtsl_config.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini)
+and a
+[`ubtsl_profiles.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini)
+file from the `{home}/.lucit/` and the current working directory. Alternatively, you can specify these files explicitly with the
 `--configfile` and `--profilesfile` parameters.
 
 Once the tool is started, it trails the stop/loss order until it is completely fulfilled, sends the notifications, and
@@ -66,54 +45,55 @@ then it stops.
 
 ***Supported exchanges:***
 
-| Exchange                                           | Exchange string               | trail                                                                                                                                     | jump-in-and-trail                                                                                                                                        | 
-|----------------------------------------------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| [Binance](https://www.binance.com)                 | `binance.com`                 | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/x-icon.png)                  |
-| [Binance Testnet](https://testnet.binance.vision/) | `binance.com-testnet`         | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/x-icon.png)                  |
-| [Binance Futures](https://www.binance.com)         | `binance.com-futures`         | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/x-icon.png)                 |
-| [Binance Isolated Margin](https://www.binance.com) | `binance.com-isolated_margin` | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) (experimental) |
-| [Binance Margin](https://www.binance.com)          | `binance.com-margin`          | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/ok-icon.png) | ![yes](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/x-icon.png)                 |
+| Exchange                                           | Exchange string               | trail | jump-in-and-trail |
+|----------------------------------------------------|-------------------------------|-------|--------------------|
+| [Binance](https://www.binance.com)                 | `binance.com`                 | yes   | no                 |
+| [Binance Testnet](https://testnet.binance.vision/) | `binance.com-testnet`         | yes   | no                 |
+| [Binance Futures](https://www.binance.com)         | `binance.com-futures`         | yes   | no                 |
+| [Binance Isolated Margin](https://www.binance.com) | `binance.com-isolated_margin` | yes   | yes (experimental) |
+| [Binance Margin](https://www.binance.com)          | `binance.com-margin`          | yes   | no                 |
 
 ## Installation
-The CLI interface `ubtsl`/`ubtsl.exe` is installed during the 
-[installation of `unicorn-binance-trailing-stop-loss`](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html#installation-and-upgrade) 
-with `pip` or `conda` and is used to interact with the [`unicorn-binance-trailing-stop-loss`](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html) Python library.
 
-Every parameter that can be configured via the [`ubtsl_profiles.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini) 
-or the [`ubtsl_config.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini) 
-file can also be defined as a command line argument. Therefore, both files are not mandatory, but it increases the 
+```
+pip install unicorn-binance-trailing-stop-loss
+```
+
+Every parameter that can be configured via the [`ubtsl_profiles.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini)
+or the [`ubtsl_config.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini)
+file can also be defined as a command line argument. Therefore, both files are not mandatory, but they increase the
 usability immensely.
 
 ### Create `ubtsl_config.ini`
 A fresh `ubtsl_config.ini` file can be created with the following command
 
 ```sh
-$ ubtsl --createconfigini 
+$ ubtsl --createconfigini
 ```
 
 ### Create `ubtsl_profiles.ini`
 The same command is available for the `ubtsl_profiles.ini` file:
 
 ```sh
-$ ubtsl --createprofilesini 
+$ ubtsl --createprofilesini
 ```
 
 ### Open `ubtsl_config.ini`
-Open the used `ubtsl_config.ini` file in a GUI editor: 
+Open the used `ubtsl_config.ini` file in a GUI editor:
 
 ```sh
-$ ubtsl --openconfigini 
+$ ubtsl --openconfigini
 ```
 
 ### Open `ubtsl_profiles.ini`
 The same command is available for the `ubtsl_profiles.ini` file:
 
 ```sh
-$ ubtsl --openprofilesini 
+$ ubtsl --openprofilesini
 ```
 
 ### Test the notification settings
-If you entered valid email and/or Telegram settings you can test the notification system:
+If you entered valid email settings you can test the notification system:
 
 ```sh
 $ ubtsl --test notification
@@ -133,7 +113,7 @@ Test the data streams, this test needs a defined exchange and market parameter:
 $ ubtsl --test streams --exchange binance.com --market BTCUSDT
 ```
 
-It is possible to use `exchange` and `market` values of a profile. 
+It is possible to use `exchange` and `market` values of a profile.
 
 ```sh
 $ ubtsl --profile "BTCUSDT_SELL" --test streams
@@ -161,7 +141,7 @@ $ py -m ubtsl --help
 
 ### Load a profile
 
-If profiles are available, they can be activated with the `--profile` parameter at startup. 
+If profiles are available, they can be activated with the `--profile` parameter at startup.
 
 ```sh
 $ ubtsl --profile BTCUSDT_SELL
@@ -169,85 +149,11 @@ $ ubtsl --profile BTCUSDT_SELL
 
 ### Command line arguments
 
-Instead of loading the values from profiles, they can also be defined explicitly via command line parameters. 
+Instead of loading the values from profiles, they can also be defined explicitly via command line parameters.
 
 Any CLI parameters will overwrite predefined values from the profile.
 
 All parameters that expect numbers can be configured with fixed numerical values as well as with percentage values.
-
-```sh
-$ ubtsl --help
-usage: ubtsl [-h] [-ak APIKEY] [-as APISECRET] [-bt BORROWTHRESHOLD] [-coo] [-cci] [-cpi] [-cf CONFIGFILE] [-cu]
-             [-ex EXAMPLE] [-e EXCHANGE] [-n ENGINE] [-k KEEPTHRESHOLD] [-lf LOGFILE] [-ll LOGLEVEL] [-loo]
-             [-m MARKET] [-oci] [-opi] [-ot ORDERTYPE] [-pf PROFILE] [-pff PROFILESFILE] [-r RESETSTOPLOSSPRICE]
-             [-l STOPLOSSLIMIT] [-sl STOPLOSSSTARTLIMIT] [-p STOPLOSSPRICE] [-t TEST] [-v]
-
-UNICORN Binance Trailing Stop Loss 0.7.1 by LUCIT Systems and Development (MIT License)
-
-options:
-  -h, --help            show this help message and exit
-  -ak APIKEY, --apikey APIKEY
-                        the API key
-  -as APISECRET, --apisecret APISECRET
-                        The Binance API secret.
-  -bt BORROWTHRESHOLD, --borrowthreshold BORROWTHRESHOLD
-                        How much of the possible credit line to exhaust. (Only available in Margin)
-  -coo, --cancelopenorders
-                        Cancel all open orders and then stop. Only valid in combination with parameter `exchange` and
-                        `market`.
-  -cci, --createconfigini
-                        Create the config file and then stop.
-  -cpi, --createprofilesini
-                        Create the profiles file and then stop.
-  -cf CONFIGFILE, --configfile CONFIGFILE
-                        Specify path including filename to the config file (ex: `~/my_config.ini`). If not provided
-                        ubtsl tries to load a `ubtsl_config.ini` from the `{home}\.lucit\` and the current
-                        working directory.
-  -cu, --checkupdate    Check if update is available and then stop.
-  -ex EXAMPLE, --example EXAMPLE
-                        Show an example ini file from GitHub and then stop. Options: `config` or `profiles`.
-  -e EXCHANGE, --exchange EXCHANGE
-                        Exchange: binance.com, binance.com-testnet, binance.com-futures, binance.com-isolated_margin,
-                        binance.com-margin
-  -n ENGINE, --engine ENGINE
-                        Choose the engine. Default: `trail` Options: `jump-in-and-trail` to place a buy order and
-                        trail
-  -k KEEPTHRESHOLD, --keepthreshold KEEPTHRESHOLD
-                        Set the threshold to be kept. This is the amount that will not get sold.
-  -lf LOGFILE, --logfile LOGFILE
-                        Specify path including filename to the logfile.
-  -ll LOGLEVEL, --loglevel LOGLEVEL
-                        Choose a loglevel. Default: INFO Options: DEBUG, INFO, WARNING, ERROR and CRITICAL
-  -loo, --listopenorders
-                        List all open orders and then stop. Only valid in combination with parameter `exchange` and
-                        `market`.
-  -m MARKET, --market MARKET
-                        The market on which is traded.
-  -oci, --openconfigini
-                        Open the used config file and then stop.
-  -opi, --openprofilesini
-                        Open the used profiles file and then stop.
-  -ot ORDERTYPE, --ordertype ORDERTYPE
-                        Use `limit` or `market`.
-  -pf PROFILE, --profile PROFILE
-                        Name of the profile to load from ubtsl_profiles.ini!
-  -pff PROFILESFILE, --profilesfile PROFILESFILE
-                        Specify path including filename to the profiles file (ex: `~/my_profiles.ini`). If not
-                        available ubtsl tries to load a ubtsl_profile.ini from the `{home}\.lucit\` and the
-                        current working directory.
-  -r RESETSTOPLOSSPRICE, --resetstoplossprice RESETSTOPLOSSPRICE
-                        Reset the existing stop_loss_price! usage: True anything else is False.
-  -l STOPLOSSLIMIT, --stoplosslimit STOPLOSSLIMIT
-                        Stop/loss limit in float or percent.
-  -sl STOPLOSSSTARTLIMIT, --stoplossstartlimit STOPLOSSSTARTLIMIT
-                        Set the start stop/loss limit in float or percent.
-  -p STOPLOSSPRICE, --stoplossprice STOPLOSSPRICE
-                        Set the start stop/loss price as float value.
-  -t TEST, --test TEST  Use this to test specific systems like "notification", "binance-connectivity" and "streams".
-                        The streams test needs a valid exchange and market. If test is not None the engine will NOT
-                        start! It only tests!
-  -v, --version         Show the program version and then stop. the version is `0.7.1` by the way :)
-```
 
 ## Example commands
 ### Check if a new update is available
@@ -272,11 +178,11 @@ $ ubtsl --profile BTCUSDT_SELL --stoplosslimit 0.5%
 ### Smart entry
 ***This function is still in an experimental phase and only available for Isolated Margin.***
 
-Do a smart entry by using `engine = jump-in-and-trail` like it is defined within the profile `BTCUSDT_SMART_ENTRY` 
+Do a smart entry by using `engine = jump-in-and-trail` like it is defined within the profile `BTCUSDT_SMART_ENTRY`
 of the [example_ubtsl_profiles.ini](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini).
 
-By activating the `jump-in-and-trail` engine, it first buys the predefined asset amount and then trails them 
-automatically. 
+By activating the `jump-in-and-trail` engine, it first buys the predefined asset amount and then trails them
+automatically.
 
 ```sh
 $ ubtsl --profile BTCUSDT_SMART_ENTRY
@@ -286,10 +192,10 @@ $ ubtsl --profile BTCUSDT_SMART_ENTRY
 Get a list of all open orders.
 
 ```sh
-$ ubtsl --exchange "binance.com" --market "BTCUSDT" --listopenorders 
+$ ubtsl --exchange "binance.com" --market "BTCUSDT" --listopenorders
 ```
 
-It is possible to use `exchange` and `market` values of a profile. 
+It is possible to use `exchange` and `market` values of a profile.
 
 ```sh
 $ ubtsl --profile "BTCUSDT_SELL" --listopenorders
@@ -298,96 +204,35 @@ $ ubtsl --profile "BTCUSDT_SELL" --listopenorders
 ### Cancel all open orders
 
 ```sh
-$ ubtsl --exchange "binance.com" --market "BTCUSDT" --cancelopenorders 
+$ ubtsl --exchange "binance.com" --market "BTCUSDT" --cancelopenorders
 ```
 
 It's possible to use `exchange` and `market` values of a profile.
 
 ```sh
-$ ubtsl --profile "BTCUSDT_SELL" --listopenorders
+$ ubtsl --profile "BTCUSDT_SELL" --cancelopenorders
 ```
 
 ## Example files
 - [example_ubtsl_config.ini](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini)
 - [example_ubtsl_profiles.ini](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini)
 
-## Change Log
-[https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/CHANGELOG.html](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/CHANGELOG.html)
-
 ## Documentation
-- [General](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech)
-- [Modules](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/unicorn_binance_trailing_stop_loss.html)
-- [CLI](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/CLI.html)
-
-## Project Homepage
-[https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss)
-
-## Wiki
-[https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/wiki](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/wiki)
-
-## Social
-- [Discussions](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/discussions)
-- [https://t.me/unicorndevs](https://t.me/unicorndevs)
-- [https://dev.binance.vision](https://dev.binance.vision)
-- [https://community.binance.org](https://community.binance.org)
-
-## Receive Notifications
-To receive notifications on available updates you can 
-[![watch](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/watch.png)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/watchers) 
-the repository on [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss).
-
-Follow us on [Twitter](https://twitter.com/LUCIT_SysDev) or on [Facebook](https://www.facebook.com/lucit.systems.and.development) 
-for general news about the [unicorn-binance-suite](https://www.lucit.tech/unicorn-binance-suite.html)!
-
-To receive news (like inspection windows/maintenance) about the Binance API`s subscribe to their telegram groups: 
-
-- [https://t.me/binance_api_announcements](https://t.me/binance_api_announcements)
-- [https://t.me/binance_api_english](https://t.me/binance_api_english)
-- [https://t.me/Binance_JEX_EN](https://t.me/Binance_JEX_EN)
-- [https://t.me/Binance_USA](https://t.me/Binance_USA)
-- [https://t.me/TRBinanceTR](https://t.me/TRBinanceTR)
-- [https://t.me/BinanceDEXchange](https://t.me/BinanceDEXchange)
-- [https://t.me/BinanceExchange](https://t.me/BinanceExchange)
-
-## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - 
-click ![thumbs-up](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
-
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
-and Python version and explain how to reproduce the error. A demo script is appreciated.
-
-If you dont find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues)!
-
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/security/policy)
+- [General](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss)
+- [Modules](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/modules.html)
+- [CLI](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html)
 
 ## Contributing
-[UNICORN Binance Trailing Stop Loss](https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html) is an open 
-source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
-contribute follow 
+[UNICORN Binance Trailing Stop Loss](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss) is an open
+source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To
+contribute follow
 [this guide](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/CONTRIBUTING.md).
- 
-### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-trailing-stop-loss)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/graphs/contributors)
-
-We ![love](https://raw.githubusercontent.com/lucit-systems-and-development/unicorn-binance-trailing-stop-loss/master/images/misc/heart.png) open source!
-
-## You want to say Thank You?
-We hope you are enjoying using our libraries and that they are proving to be useful to you. If you have a moment, we would greatly appreciate it if you could leave us a [review on Google](https://g.page/r/CbfHlcs8BfG8EAg/review). Thank you for your support!
 
 ## Disclaimer
-This project is for informational purposes only. You should not construe this information or any other material as 
-legal, tax, investment, financial or other advice. Nothing contained herein constitutes a solicitation, recommendation, 
-endorsement or offer by us or any third party provider to buy or sell any securities or other financial instruments in 
-this or any other jurisdiction in which such solicitation or offer would be unlawful under the securities laws of such 
-jurisdiction.
+This project is for informational purposes only. Nothing contained herein constitutes financial advice or a
+solicitation to buy or sell securities.
 
 ***If you intend to use real money, use it at your own risk.***
 
-Under no circumstances will we be responsible or liable for any claims, damages, losses, expenses, costs or liabilities 
+Under no circumstances will we be responsible or liable for any claims, damages, losses, expenses, costs or liabilities
 of any kind, including but not limited to direct or indirect damages for loss of profits.
-
-## Commercial Support
-
-[![Get professional and fast support](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/support/LUCIT-get-professional-and-fast-support.png)](https://www.lucit.tech/get-support.html)
-
-***Do you need a developer, operator or consultant?*** [Contact us](https://www.lucit.tech/contact.html) for a non-binding initial consultation!


### PR DESCRIPTION
## Summary

**README.md:**
- Replace all `docs.lucit.tech` URLs with `oliver-zehentleitner.github.io` (GitHub Pages)

**cli/README.md** (complete rewrite):
- Remove LUCIT license banner, shop links, Commercial Support section
- Remove Twitter/Facebook LUCIT social links, Google Review section
- Replace `docs.lucit.tech` URLs with GitHub Pages
- Replace image-based exchange support table with plain text
- Remove Telegram notification reference (not a UBTSL feature)
- Remove outdated `--help` output (showed version 0.7.1 / LUCIT branding)
- Streamline badges and sections to match main README style

## Test plan
- [ ] No `lucit.tech`, `shop.lucit`, `medium.lucit`, or `LUCIT` references remain in README.md or cli/README.md