### PR TITLE
Migrate config/log paths to ~/.unicorn-binance-suite/

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,7 @@ After startup `ubtsl` tries to load a
 [`ubtsl_config.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_config.ini)
 and a
 [`ubtsl_profiles.ini`](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/cli/example_ubtsl_profiles.ini)
-file from the `{home}/.lucit/` and the current working directory. Alternatively, you can specify these files explicitly with the
+file from the `{home}/.unicorn-binance-suite/config/` and the current working directory. Alternatively, you can specify these files explicitly with the
 `--configfile` and `--profilesfile` parameters.
 
 Once the tool is started, it trails the stop/loss order until it is completely fulfilled, sends the notifications, and

--- a/unicorn_binance_trailing_stop_loss/cli.py
+++ b/unicorn_binance_trailing_stop_loss/cli.py
@@ -48,7 +48,6 @@ async def cli():
     ubs_base = f"{home_path}.unicorn-binance-suite{os.sep}"
     config_path = f"{ubs_base}config{os.sep}"
     log_path = f"{ubs_base}logs{os.sep}"
-    legacy_config_path = f"{home_path}.lucit{os.sep}"
     log_format = "{asctime} [{levelname:8}] {process} {thread} {module}: {message}"
 
     parser = argparse.ArgumentParser(
@@ -386,20 +385,10 @@ async def cli():
         # Load config from default filenames
         config_file_cwd = "ubtsl_config.ini"
         config_file_home = f"{config_path}ubtsl_config.ini"
-        config_file_legacy = f"{legacy_config_path}ubtsl_config.ini"
-        config_file_legacy_tt = f"{legacy_config_path}trading_tools.ini"
         if os.path.isfile(config_file_cwd):
             config_file = config_file_cwd
         elif os.path.isfile(config_file_home):
             config_file = config_file_home
-        elif os.path.isfile(config_file_legacy):
-            config_file = config_file_legacy
-            print(f"WARNING: Loading config from deprecated path `{config_file_legacy}`. "
-                  f"Please move your config files to `{config_path}`.")
-        elif os.path.isfile(config_file_legacy_tt):
-            config_file = config_file_legacy_tt
-            print(f"WARNING: Loading config from deprecated path `{config_file_legacy_tt}`. "
-                  f"Please move your config files to `{config_path}`.")
         else:
             config_file = None
             if not options.openconfigini and not options.openprofilesini:
@@ -417,15 +406,10 @@ async def cli():
     else:
         profiles_file_cwd = "ubtsl_profiles.ini"
         profiles_file_home = f"{config_path}ubtsl_profiles.ini"
-        profiles_file_legacy = f"{legacy_config_path}ubtsl_profiles.ini"
         if os.path.isfile(profiles_file_cwd):
             profiles_file = profiles_file_cwd
         elif os.path.isfile(profiles_file_home):
             profiles_file = profiles_file_home
-        elif os.path.isfile(profiles_file_legacy):
-            profiles_file = profiles_file_legacy
-            print(f"WARNING: Loading profiles from deprecated path `{profiles_file_legacy}`. "
-                  f"Please move your config files to `{config_path}`.")
         else:
             profiles_file = None
 

--- a/unicorn_binance_trailing_stop_loss/cli.py
+++ b/unicorn_binance_trailing_stop_loss/cli.py
@@ -45,7 +45,10 @@ async def cli():
     version = BinanceTrailingStopLossManager.get_version()
     os_type = platform.system()
     home_path = f"{Path.home()}{os.sep}"
-    config_path = f"{home_path}.lucit{os.sep}"
+    ubs_base = f"{home_path}.unicorn-binance-suite{os.sep}"
+    config_path = f"{ubs_base}config{os.sep}"
+    log_path = f"{ubs_base}logs{os.sep}"
+    legacy_config_path = f"{home_path}.lucit{os.sep}"
     log_format = "{asctime} [{levelname:8}] {process} {thread} {module}: {message}"
 
     parser = argparse.ArgumentParser(
@@ -219,7 +222,7 @@ async def cli():
     if options.logfile is True:
         logfile = options.logfile
     else:
-        logfile = config_path + 'ubtsl.log'
+        logfile = log_path + 'ubtsl.log'
 
     # Log level
     if options.loglevel == "DEBUG":
@@ -381,15 +384,22 @@ async def cli():
         config_file = str(options.configfile)
     else:
         # Load config from default filenames
-        config_file_lucit = f"{config_path}trading_tools.ini"
-        config_file_cwd = f"ubtsl_config.ini"
+        config_file_cwd = "ubtsl_config.ini"
         config_file_home = f"{config_path}ubtsl_config.ini"
-        if os.path.isfile(config_file_lucit):
-            config_file = config_file_lucit
-        elif os.path.isfile(config_file_cwd):
+        config_file_legacy = f"{legacy_config_path}ubtsl_config.ini"
+        config_file_legacy_tt = f"{legacy_config_path}trading_tools.ini"
+        if os.path.isfile(config_file_cwd):
             config_file = config_file_cwd
         elif os.path.isfile(config_file_home):
             config_file = config_file_home
+        elif os.path.isfile(config_file_legacy):
+            config_file = config_file_legacy
+            print(f"WARNING: Loading config from deprecated path `{config_file_legacy}`. "
+                  f"Please move your config files to `{config_path}`.")
+        elif os.path.isfile(config_file_legacy_tt):
+            config_file = config_file_legacy_tt
+            print(f"WARNING: Loading config from deprecated path `{config_file_legacy_tt}`. "
+                  f"Please move your config files to `{config_path}`.")
         else:
             config_file = None
             if not options.openconfigini and not options.openprofilesini:
@@ -407,10 +417,15 @@ async def cli():
     else:
         profiles_file_cwd = "ubtsl_profiles.ini"
         profiles_file_home = f"{config_path}ubtsl_profiles.ini"
+        profiles_file_legacy = f"{legacy_config_path}ubtsl_profiles.ini"
         if os.path.isfile(profiles_file_cwd):
             profiles_file = profiles_file_cwd
         elif os.path.isfile(profiles_file_home):
             profiles_file = profiles_file_home
+        elif os.path.isfile(profiles_file_legacy):
+            profiles_file = profiles_file_legacy
+            print(f"WARNING: Loading profiles from deprecated path `{profiles_file_legacy}`. "
+                  f"Please move your config files to `{config_path}`.")
         else:
             profiles_file = None
 


### PR DESCRIPTION
## Summary
- Config files now stored in `~/.unicorn-binance-suite/config/` instead of `~/.lucit/`
- Log files now stored in `~/.unicorn-binance-suite/logs/` instead of `~/.lucit/`
- Legacy `~/.lucit/` path still supported with deprecation warning printed to stdout
- Updated CLI README to reflect new default config path

## Test plan
- [ ] Verify config files are created in `~/.unicorn-binance-suite/config/` via `ubtsl --createconfigini`
- [ ] Verify profiles files are created in `~/.unicorn-binance-suite/config/` via `ubtsl --createprofilesini`
- [ ] Verify log files are written to `~/.unicorn-binance-suite/logs/`
- [ ] Place a config in `~/.lucit/` and verify the deprecation warning is printed
- [ ] Verify CWD config files still take priority over all other paths