### PR TITLE
Add MANIFEST.in so the sdist ships the package sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/readme.html#installation-and-upgrade)
 
 ## 1.3.0.dev (development stage/unreleased/unstable)
+### Fixed
+- Added `MANIFEST.in` so the source tarball on PyPI actually ships the
+  Python sources of the package. Previously only `setup.py` was included
+  which made the sdist unbuildable (e.g. conda-forge builds from sdist).
 
 ## 1.3.0
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include unicorn_binance_trailing_stop_loss *.py *.pyi *.c *.pyx *.so *.dll *.pyd


### PR DESCRIPTION
## Problem
The PyPI sdist of `unicorn-binance-trailing-stop-loss 1.3.0` contains no package sources at all — only `setup.py`, `pyproject.toml`, `LICENSE`, `README`. Nothing from `unicorn_binance_trailing_stop_loss/` makes it into the tarball. As a result the sdist is unbuildable:

```
$ pip install unicorn-binance-trailing-stop-loss-1.3.0.tar.gz
  error: package directory 'unicorn_binance_trailing_stop_loss' does not exist
```

conda-forge builds from sdist, so this blocks the 1.3.0 migration (feedstock PR #16 merged, main build is stuck).

## Cause
There was no `MANIFEST.in` at all, and `include_package_data` isn't turned on.

## Fix
Added a `MANIFEST.in` with `recursive-include` covering `*.py`, `*.pyi`, `*.c`, `*.pyx`, `*.so`, `*.dll`, `*.pyd`. CHANGELOG entry added.

## Release implications
Needs a 1.3.1 sdist respin on PyPI; the conda-forge recipe will then be bumped on top.