### PR TITLE
Replace remaining lucit.tech URLs with github equivalents

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://shop.lucit.services"]
+custom: ["https://github.com/sponsors/oliver-zehentleitner"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/discussions
     about: Ask general questions.
   - name: UNICORN Binance Trailing Stop Loss documentation
-    url: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/
+    url: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/
     about: The complete UNICORN Binance Trailing Stop Loss documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.3.0.dev (development stage/unreleased/unstable)
 ### Changed
+- Replaced all remaining `lucit.tech` URLs in source files, tests and
+  config with their github.com / github.io equivalents:
+  - Package headers (`manager.py`, `cli.py`, `__init__.py`,
+    `unittest_binance_trailing_stop_loss.py`, `example_binance_trailing_stop_loss.py`,
+    `dev/set_version.py`): project website, docs URL, changelog URL
+    and setup.py/pyproject.toml project_urls.
+  - `.github/ISSUE_TEMPLATE/config.yml`: documentation link.
+  - `.github/FUNDING.yml`: `shop.lucit.services` → `github.com/sponsors/oliver-zehentleitner`.
+  - `SECURITY.md`: replaced the lucit.tech contact form URL with the
+    GitHub Security Advisories private-reporting URL.
+  - `CODE_OF_CONDUCT.md`: replaced the lucit.tech contact form URL
+    with the project maintainer's GitHub profile.
+### Changed
 - README: switched all conda references from the legacy `lucit` channel
   to `conda-forge`. Added conda-forge version / downloads / feedstock
   build badges. Replaced the old multi-channel install block with a

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at https://www.lucit.tech/contact-unicorn-developers.html. 
+reported by contacting the project team at https://github.com/oliver-zehentleitner. 
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ This document outlines security procedures and general policies for the
 Thank you for improving the security of `unicorn-binance-trailing-stop-loss`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs via our contact form: 
-https://www.lucit.tech/contact-unicorn-developers.html
+Please report security bugs privately via GitHub Security Advisories:
+https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/security/advisories/new
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling

--- a/dev/set_version.py
+++ b/dev/set_version.py
@@ -4,9 +4,9 @@
 # File: dev/set_version.sh
 #
 # Part of ‘UNICORN Binance Local Depth Cache’
-# Project website: https://www.lucit.tech/unicorn-binance-local-depth-cache.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
-# Documentation: https://unicorn-binance-local-depth-cache.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache
 # PyPI: https://pypi.org/project/unicorn-binance-local-depth-cache
 
 #

--- a/example_binance_trailing_stop_loss.py
+++ b/example_binance_trailing_stop_loss.py
@@ -4,9 +4,9 @@
 # File: example_binance_trailing_stop_loss.py
 #
 # Part of ‘UNICORN Binance Trailing Stop Loss’
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,16 @@ description = "A Python library with a command line interface for a trailing sto
 authors = ["Oliver Zehentleitner"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html"
-documentation = "https://unicorn-binance-trailing-stop-loss.docs.lucit.tech"
+homepage = "https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss"
+documentation = "https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss"
 repository = "https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss"
 
 [tool.poetry.urls]
-'Howto' = 'https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html#howto'
-'Documentation' = 'https://unicorn-binance-trailing-stop-loss.docs.lucit.tech'
+'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss#howto'
+'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss'
 'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/wiki'
 'Author' = 'https://about.me/oliver-zehentleitner'
-'Changes' = 'https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/changelog.html'
+'Changes' = 'https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/changelog.html'
 'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/LICENSE'
 'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues'
 'Telegram' = 'https://t.me/unicorndevs'

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@
 # File: setup.py
 #
 # Part of 'UNICORN Binance Trailing Stop Loss'
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 #
 # License: MIT
@@ -44,10 +44,10 @@ setup(
      keywords='Binance, Binance Futures, Binance Margin, Binance Isolated Margin, Binance Testnet, Trailing Stop Loss, '
               'Smart Entry',
      project_urls={
-        'Documentation': 'https://unicorn-binance-trailing-stop-loss.docs.lucit.tech',
+        'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss',
         'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/wiki',
         'Author': 'https://about.me/oliver-zehentleitner',
-        'Changes': 'https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/changelog.html',
+        'Changes': 'https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/changelog.html',
         'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/LICENSE',
         'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/issues',
         'Telegram': 'https://t.me/unicorndevs',

--- a/unicorn_binance_trailing_stop_loss/__init__.py
+++ b/unicorn_binance_trailing_stop_loss/__init__.py
@@ -4,9 +4,9 @@
 # File: unicorn_binance_trailing_stop_loss/__init__.py
 #
 # Part of 'UNICORN Binance Trailing Stop Loss'
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 #
 # License: MIT

--- a/unicorn_binance_trailing_stop_loss/cli.py
+++ b/unicorn_binance_trailing_stop_loss/cli.py
@@ -4,9 +4,9 @@
 # File: unicorn_binance_trailing_stop_loss/cli.py
 #
 # Part of ‘UNICORN Binance Trailing Stop Loss’
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 #
 # License: MIT
@@ -40,7 +40,7 @@ async def cli():
     """
         UNICORN Binance Trailing Stop Loss Command Line Interface Documentation
 
-        More info: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/cli.html
+        More info: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/cli.html
     """
     version = BinanceTrailingStopLossManager.get_version()
     os_type = platform.system()

--- a/unicorn_binance_trailing_stop_loss/manager.py
+++ b/unicorn_binance_trailing_stop_loss/manager.py
@@ -4,9 +4,9 @@
 # File: unicorn_binance_trailing_stop_loss/manager.py
 #
 # Part of ‘UNICORN Binance Trailing Stop Loss’
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 #
 # License: MIT
@@ -260,7 +260,7 @@ class BinanceTrailingStopLossManager(threading.Thread):
                                                                                  warn_on_update=warn_on_update)
         if warn_on_update and self.is_update_available():
             update_msg = f"Release {self.name}_{self.get_latest_version()} is available, please consider updating! " \
-                         f"(Changelog: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/changelog.html)"
+                         f"(Changelog: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss/changelog.html)"
             print(update_msg)
             self.logger.warning(update_msg)
         try:

--- a/unittest_binance_trailing_stop_loss.py
+++ b/unittest_binance_trailing_stop_loss.py
@@ -4,9 +4,9 @@
 # File: unittest_binance_trailing_stop_loss.py
 #
 # Part of ‘UNICORN Binance Trailing Stop Loss’
-# Project website: https://www.lucit.tech/unicorn-binance-trailing-stop-loss.html
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
-# Documentation: https://unicorn-binance-trailing-stop-loss.docs.lucit.tech
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss
 # PyPI: https://pypi.org/project/unicorn-binance-trailing-stop-loss
 #
 # License: MIT


### PR DESCRIPTION
Follow-up cleanup of still-lingering `lucit.tech` / `lucit.services` URLs across source code, packaging metadata and GitHub config.

### Code
- `unicorn_binance_trailing_stop_loss/{manager,cli,__init__}.py`, `unittest_binance_trailing_stop_loss.py`, `example_binance_trailing_stop_loss.py`, `dev/set_version.py`: file-header URLs (project website, docs, changelog) + one runtime log message in `manager.py`.

### Packaging
- `setup.py` project_urls: `Documentation`, `Changes`.
- `pyproject.toml`: `homepage`, `documentation`, matching URLs block.

### Config
- `.github/ISSUE_TEMPLATE/config.yml`: docs contact link.
- `.github/FUNDING.yml`: `https://shop.lucit.services` → `https://github.com/sponsors/oliver-zehentleitner` (matches the other suite repos).
- `SECURITY.md`: replaced contact form URL with GitHub Security Advisories.
- `CODE_OF_CONDUCT.md`: replaced contact form URL with maintainer GitHub profile.

Sphinx sources under `dev/sphinx/source/` and historical CHANGELOG entries intentionally untouched.