### PR TITLE
Bump minimum unicorn-binance-websocket-api to 2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.3.0.dev (development stage/unreleased/unstable)
 ### Changed
+- Bumped minimum `unicorn-binance-websocket-api` dependency from
+  `>=2.1.1` to `>=2.12.2` in `setup.py`, `requirements.txt`,
+  `pyproject.toml`, `environment.yml` and `meta.yaml`. 2.12.2 is the
+  cleanup-round UBWA release; also adds support for features relied
+  on since UBWA 2.12.
 - Replaced all remaining `lucit.tech` URLs in source files, tests and
   config with their github.com / github.io equivalents:
   - Package headers (`manager.py`, `cli.py`, `__init__.py`,
@@ -21,7 +26,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     GitHub Security Advisories private-reporting URL.
   - `CODE_OF_CONDUCT.md`: replaced the lucit.tech contact form URL
     with the project maintainer's GitHub profile.
-### Changed
 - README: switched all conda references from the legacy `lucit` channel
   to `conda-forge`. Added conda-forge version / downloads / feedstock
   build badges. Replaced the old multi-channel install block with a

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - Cython
   - requests
   - unicorn-binance-rest-api>=2.2.0
-  - unicorn-binance-websocket-api>=2.1.1
+  - unicorn-binance-websocket-api>=2.12.2

--- a/meta.yaml
+++ b/meta.yaml
@@ -25,13 +25,13 @@ requirements:
     - Cython
     - requests
     - unicorn-binance-rest-api >=2.2.0
-    - unicorn-binance-websocket-api >=2.1.1
+    - unicorn-binance-websocket-api >=2.12.2
   run:
     - python
     - Cython
     - requests
     - unicorn-binance-rest-api >=2.2.0
-    - unicorn-binance-websocket-api >=2.1.1
+    - unicorn-binance-websocket-api >=2.12.2
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python = ">=3.9.0"
 Cython = "*"
 requests = "*"
 unicorn-binance-rest-api = ">=2.2.0"
-unicorn-binance-websocket-api = ">=2.1.1"
+unicorn-binance-websocket-api = ">=2.12.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@
 Cython
 requests
 unicorn-binance-rest-api>=2.2.0
-unicorn-binance-websocket-api>=2.1.1
+unicorn-binance-websocket-api>=2.12.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',
-     install_requires=['Cython', 'requests', 'unicorn-binance-websocket-api>=2.1.1',
+     install_requires=['Cython', 'requests', 'unicorn-binance-websocket-api>=2.12.2',
                        'unicorn-binance-rest-api>=2.2.0'],
      keywords='Binance, Binance Futures, Binance Margin, Binance Isolated Margin, Binance Testnet, Trailing Stop Loss, '
               'Smart Entry',


### PR DESCRIPTION
2.12.2 is the cleanup-round UBWA release. Bumping the constraint across all five dependency files (setup.py as source of truth).