### PR TITLE
deps: bump unicorn-binance-websocket-api to >=2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.3.1.dev (development stage/unreleased/unstable)
 
+## 1.3.2
+### Changed
+- Bumped minimum `unicorn-binance-websocket-api` dependency from
+  `>=2.12.2` to `>=2.13.0` in `setup.py`, `requirements.txt`,
+  `pyproject.toml`, `environment.yml` and `meta.yaml`. UBWA 2.13.0
+  introduces the per-category Futures WebSocket routing
+  (`/public`, `/market`, `/private`) required by Binance since
+  2026-04-23 and raises `ValueError` on mixed-category streams.
+  See
+  [unicorn-binance-websocket-api#437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437).
+
 ## 1.3.1
 ### Changed
 - Bumped minimum `unicorn-binance-websocket-api` dependency from

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - Cython
   - requests
   - unicorn-binance-rest-api>=2.2.0
-  - unicorn-binance-websocket-api>=2.12.2
+  - unicorn-binance-websocket-api>=2.13.0

--- a/meta.yaml
+++ b/meta.yaml
@@ -25,13 +25,13 @@ requirements:
     - Cython
     - requests
     - unicorn-binance-rest-api >=2.2.0
-    - unicorn-binance-websocket-api >=2.12.2
+    - unicorn-binance-websocket-api >=2.13.0
   run:
     - python
     - Cython
     - requests
     - unicorn-binance-rest-api >=2.2.0
-    - unicorn-binance-websocket-api >=2.12.2
+    - unicorn-binance-websocket-api >=2.13.0
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python = ">=3.9.0"
 Cython = "*"
 requests = "*"
 unicorn-binance-rest-api = ">=2.2.0"
-unicorn-binance-websocket-api = ">=2.12.2"
+unicorn-binance-websocket-api = ">=2.13.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@
 Cython
 requests
 unicorn-binance-rest-api>=2.2.0
-unicorn-binance-websocket-api>=2.12.2
+unicorn-binance-websocket-api>=2.13.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',
-     install_requires=['Cython', 'requests', 'unicorn-binance-websocket-api>=2.12.2',
+     install_requires=['Cython', 'requests', 'unicorn-binance-websocket-api>=2.13.0',
                        'unicorn-binance-rest-api>=2.2.0'],
      keywords='Binance, Binance Futures, Binance Margin, Binance Isolated Margin, Binance Testnet, Trailing Stop Loss, '
               'Smart Entry',


### PR DESCRIPTION
## Summary

Raises the minimum UBWA pin from `>=2.12.2` to `>=2.13.0` across all suite files (`setup.py`, `requirements.txt`, `pyproject.toml`, `environment.yml`, `meta.yaml`).

## Why

UBWA 2.13.0 introduces the per-category USDT-M Futures WebSocket routing (`/public`, `/market`, `/private`) required by Binance since the 2026-04-23 cutoff, and raises `ValueError` on mixed-category streams. Pinning UBTSL to `>=2.13.0` ensures Futures trailing stops keep working when Binance fully retires the legacy paths.

Reference: [unicorn-binance-websocket-api#437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437) / [PR #441](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/441).

## Notes

- No version bump in this PR — the pin update will roll out with the next regular UBTSL release.
- CHANGELOG entry added under a `## 1.3.2` placeholder section per the project's dev-stage convention; rename if you bundle this into a different version on release.