### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 ===========
 
-Copyright (c) 2022-2025 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
+Copyright (c) 2022-2026 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dev/pypi/create_wheel.sh
+++ b/dev/pypi/create_wheel.sh
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 security-check() {

--- a/dev/pypi/install_packaging_tools.sh
+++ b/dev/pypi/install_packaging_tools.sh
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 python3 -m pip install --user --upgrade pip setuptools wheel twine tqdm

--- a/dev/pypi/remove_files.sh
+++ b/dev/pypi/remove_files.sh
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 rm ./build -r

--- a/dev/pypi/upload_wheel.sh
+++ b/dev/pypi/upload_wheel.sh
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # create this file:

--- a/dev/set_version.py
+++ b/dev/set_version.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 import sys

--- a/example_binance_trailing_stop_loss.py
+++ b/example_binance_trailing_stop_loss.py
@@ -15,7 +15,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from unicorn_binance_trailing_stop_loss.manager import BinanceTrailingStopLossManager

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from setuptools import setup

--- a/unicorn_binance_trailing_stop_loss/__init__.py
+++ b/unicorn_binance_trailing_stop_loss/__init__.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from .cli import *

--- a/unicorn_binance_trailing_stop_loss/cli.py
+++ b/unicorn_binance_trailing_stop_loss/cli.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 try:

--- a/unicorn_binance_trailing_stop_loss/manager.py
+++ b/unicorn_binance_trailing_stop_loss/manager.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from unicorn_binance_rest_api import BinanceRestApiManager, BinanceAPIException

--- a/unittest_binance_trailing_stop_loss.py
+++ b/unittest_binance_trailing_stop_loss.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from unicorn_binance_trailing_stop_loss.cli import main


### PR DESCRIPTION
## Summary
- Bump copyright year from 2025 to 2026 in LICENSE + source headers
- Pattern: only modify lines containing \`Copyright\` to avoid touching unrelated 2025 occurrences
- Auto-generated files (\`docs/\`, \`dev/sphinx/\`) intentionally untouched — regenerated on next build

## Test plan
- [ ] LICENSE shows 2022-2026
- [ ] No unintended 2025→2026 changes in non-copyright lines