### PR TITLE
fix: SPOT/iso-margin trail crashes + fail-loud on missing balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/readme.html#installation-and-upgrade)
 
 ## 1.3.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `BinanceTrailingStopLossManager.get_open_orders()` return type
+  annotation was `Optional[dict]` while Binance's
+  `GET /api/v3/openOrders`, `cancel_all_open_margin_orders` and
+  `futures_get_open_orders` all return a `list`. The Cython-compiled
+  module enforced the dict annotation and raised
+  `TypeError: Expected dict, got list` on SPOT/Margin engine start
+  whenever an open order existed for the symbol. Corrected the
+  annotation and docstring to `Optional[list]`.
+- `BinanceTrailingStopLossManager.process_price_feed_stream()` passed
+  the raw aggTrade `price` (a `str` from the Binance payload) into
+  `create_stop_loss_order(current_price=...)`, which is Cython-typed
+  as `float` and raised
+  `TypeError: Argument 'current_price' has incorrect type (expected float, got str)`.
+  The price is now converted once via `float()` and the same float
+  value is reused for `self.current_price`, the
+  `calculate_stop_loss_price()` call and the
+  `create_stop_loss_order()` call, keeping the instance attribute
+  consistent with its `float` class annotation.
+- `BinanceTrailingStopLossManager.create_stop_loss_order()` checked
+  `if self.keep_threshold is not None:` but the CLI initialises
+  `keep_threshold = ""`. When no `--keepthreshold` was given the
+  empty string passed the not-None gate and `float("")` raised
+  `ValueError`. Replaced with a truthy check, matching the existing
+  `borrow_threshold` / `stop_loss_start_limit` handling.
+- `self.stop_loss_quantity` was only assigned in the
+  `keep_threshold` branch (via `update_stop_loss_quantity()`), so
+  the engine's "Created stop/loss order" notification displayed the
+  stale init value `0.0` whenever no keep_threshold was used. The
+  instance attribute is now assigned after both branches with the
+  rounded quantity that is actually sent to Binance, and the
+  `calculate_stop_loss_amount()` path now also applies
+  `round_decimals_down()` for parity with the `keep_threshold`
+  path.
+- `BinanceTrailingStopLossManager.update_stop_loss_asset_amount()`
+  unpacked the `get_owning_amount()` result without checking for
+  `None`, which happens whenever the configured asset has no
+  balance / is not listed for the account (typical for
+  `binance.com-isolated_margin` if the trading pair was never
+  activated). This raised a bare
+  `TypeError: 'NoneType' object is not iterable` deep inside the
+  engine thread and left the streams running. The engine now
+  fails loud with a clear message ("Asset `X` not found on
+  `EXCHANGE` - no balance or asset not listed for this account.
+  Stopping engine."), dispatches the email/Telegram/`callback_error`
+  notifications, calls `stop_manager()` and exits, matching the
+  existing fail-loud pattern used for `symbol_info is None`.
 
 ## 1.3.2
 ### Changed

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -8,6 +8,53 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://unicorn-binance-trailing-stop-loss.docs.lucit.tech/readme.html#installation-and-upgrade)
 
 ## 1.3.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `BinanceTrailingStopLossManager.get_open_orders()` return type
+  annotation was `Optional[dict]` while Binance's
+  `GET /api/v3/openOrders`, `cancel_all_open_margin_orders` and
+  `futures_get_open_orders` all return a `list`. The Cython-compiled
+  module enforced the dict annotation and raised
+  `TypeError: Expected dict, got list` on SPOT/Margin engine start
+  whenever an open order existed for the symbol. Corrected the
+  annotation and docstring to `Optional[list]`.
+- `BinanceTrailingStopLossManager.process_price_feed_stream()` passed
+  the raw aggTrade `price` (a `str` from the Binance payload) into
+  `create_stop_loss_order(current_price=...)`, which is Cython-typed
+  as `float` and raised
+  `TypeError: Argument 'current_price' has incorrect type (expected float, got str)`.
+  The price is now converted once via `float()` and the same float
+  value is reused for `self.current_price`, the
+  `calculate_stop_loss_price()` call and the
+  `create_stop_loss_order()` call, keeping the instance attribute
+  consistent with its `float` class annotation.
+- `BinanceTrailingStopLossManager.create_stop_loss_order()` checked
+  `if self.keep_threshold is not None:` but the CLI initialises
+  `keep_threshold = ""`. When no `--keepthreshold` was given the
+  empty string passed the not-None gate and `float("")` raised
+  `ValueError`. Replaced with a truthy check, matching the existing
+  `borrow_threshold` / `stop_loss_start_limit` handling.
+- `self.stop_loss_quantity` was only assigned in the
+  `keep_threshold` branch (via `update_stop_loss_quantity()`), so
+  the engine's "Created stop/loss order" notification displayed the
+  stale init value `0.0` whenever no keep_threshold was used. The
+  instance attribute is now assigned after both branches with the
+  rounded quantity that is actually sent to Binance, and the
+  `calculate_stop_loss_amount()` path now also applies
+  `round_decimals_down()` for parity with the `keep_threshold`
+  path.
+- `BinanceTrailingStopLossManager.update_stop_loss_asset_amount()`
+  unpacked the `get_owning_amount()` result without checking for
+  `None`, which happens whenever the configured asset has no
+  balance / is not listed for the account (typical for
+  `binance.com-isolated_margin` if the trading pair was never
+  activated). This raised a bare
+  `TypeError: 'NoneType' object is not iterable` deep inside the
+  engine thread and left the streams running. The engine now
+  fails loud with a clear message ("Asset `X` not found on
+  `EXCHANGE` - no balance or asset not listed for this account.
+  Stopping engine."), dispatches the email/Telegram/`callback_error`
+  notifications, calls `stop_manager()` and exits, matching the
+  existing fail-loud pattern used for `symbol_info is None`.
 
 ## 1.3.2
 ### Changed

--- a/unicorn_binance_trailing_stop_loss/manager.py
+++ b/unicorn_binance_trailing_stop_loss/manager.py
@@ -483,12 +483,14 @@ class BinanceTrailingStopLossManager(threading.Thread):
             if self.cancel_open_stop_loss_order():
                 return True
             total, free = self.update_stop_loss_asset_amount()
-            if self.keep_threshold is not None:
+            if self.keep_threshold:
                 stop_loss_quantity = self.round_decimals_down(self.update_stop_loss_quantity(total=total,
                                                                                              free=free),
                                                               self.precision_quantity)
             else:
-                stop_loss_quantity = self.calculate_stop_loss_amount(free)
+                stop_loss_quantity = self.round_decimals_down(self.calculate_stop_loss_amount(free),
+                                                              self.precision_quantity)
+            self.stop_loss_quantity = stop_loss_quantity
 
             free = free - stop_loss_quantity
             self.stop_loss_asset_amount_free = free
@@ -638,11 +640,11 @@ class BinanceTrailingStopLossManager(threading.Thread):
         return False
 
     def get_open_orders(self,
-                        market: str = None) -> Optional[dict]:
+                        market: str = None) -> Optional[list]:
         """
         Get the open orders on a given market.
 
-        :return: dict or None
+        :return: list or None
         """
         try:
             if self.exchange == "binance.com" or self.exchange == "binance.com-testnet":
@@ -933,21 +935,23 @@ class BinanceTrailingStopLossManager(threading.Thread):
         self.logger.debug(f"BinanceTrailingStopLossManager.process_price_feed_stream(stream_data={stream_data}, "
                           f"stream_buffer_name={stream_buffer_name}) started")
         if self.is_manager_stopping() is False:
-            if stream_data.get('price'):
-                self.current_price = stream_data.get('price')
-                sl_price = self.calculate_stop_loss_price(stream_data.get('price'), self.stop_loss_limit)
+            raw_price = stream_data.get('price')
+            if raw_price:
+                current_price = float(raw_price)
+                self.current_price = current_price
+                sl_price = self.calculate_stop_loss_price(current_price, self.stop_loss_limit)
                 if self.stop_loss_price is None:
                     self.logger.info(f"BinanceTrailingStopLossManager.process_price_feed_stream() - Setting "
                                      f"stop_loss_price from None to {sl_price}!")
                     if self.print_notifications:
                         print(f"Setting stop_loss_price from None to {sl_price}!")
-                    self.create_stop_loss_order(sl_price, current_price=stream_data.get('price'))
+                    self.create_stop_loss_order(sl_price, current_price=current_price)
                 elif self.stop_loss_price < sl_price:
                     self.logger.info(f"BinanceTrailingStopLossManager.process_price_feed_stream() - Setting "
                                      f"stop_loss_price from {self.stop_loss_price} to {sl_price}!")
                     if self.print_notifications:
                         print(f"Setting stop_loss_price from {self.stop_loss_price} to {sl_price}!")
-                    self.create_stop_loss_order(sl_price, current_price=stream_data.get('price'))
+                    self.create_stop_loss_order(sl_price, current_price=current_price)
 
     @staticmethod
     def round_decimals_down(number: float,
@@ -1271,7 +1275,20 @@ class BinanceTrailingStopLossManager(threading.Thread):
         :return: tuple
         """
         if total is None or free is None:
-            total, free = self.get_owning_amount(base_asset=self.stop_loss_asset_name)
+            owning_amount = self.get_owning_amount(base_asset=self.stop_loss_asset_name)
+            if owning_amount is None:
+                msg = (f"Asset `{self.stop_loss_asset_name}` not found on `{self.exchange}` - "
+                       f"no balance or asset not listed for this account. Stopping engine.")
+                self.logger.critical(f"BinanceTrailingStopLossManager.update_stop_loss_asset_amount() - {msg}")
+                if self.print_notifications:
+                    print(f"ERROR: {msg}")
+                self.send_email_notification(msg)
+                self.send_telegram_notification(msg)
+                self.stop_manager()
+                if self.callback_error is not None:
+                    self.callback_error(msg)
+                sys.exit(1)
+            total, free = owning_amount
         self.stop_loss_asset_amount = float(total)
         self.stop_loss_asset_amount_free = float(free)
         return total, free


### PR DESCRIPTION
## Summary

Five engine-side fixes triggered while reproducing a SPOT
`RENDERUSDC` trail that crashed at start, while the same setup ran
fine under `binance.com-isolated_margin` (which had no open SL order
at the time, masking the same bugs). All five are Cython-strict-typing
or fail-loud issues in `unicorn_binance_trailing_stop_loss/manager.py`.

### Fixes

- **`get_open_orders()` return type**: `Optional[dict]` → `Optional[list]`.
  UBRA's `get_open_orders` / `get_open_margin_orders` /
  `futures_get_open_orders` all return a `list`. The Cython-compiled
  module emitted `PyDict_CheckExact` on the return and raised
  `TypeError: Expected dict, got list` on engine start whenever an
  open order existed for the symbol (verified in the generated
  `manager.c:13716`). The caller in `start()` (`for open_order in
  open_orders`) already expected a list.
- **`process_price_feed_stream()` price str→float**: aggTrade `price`
  is a `str` (Binance ships prices as strings, UnicornFy doesn't
  convert). It was passed straight into
  `create_stop_loss_order(current_price: float)` and crashed under
  Cython's strict typing. Now converted once with `float()` and the
  same value is reused for `self.current_price`, the
  `calculate_stop_loss_price()` call and the
  `create_stop_loss_order()` call, so the instance attribute also
  matches its `float` class annotation (would have caused a latent
  crash on a `CANCELED` userdata event before).
- **`keep_threshold` truthy check**: replaced
  `if self.keep_threshold is not None:` with `if self.keep_threshold:`.
  `cli.py` initialises `keep_threshold = ""` and the not-None gate
  let the empty string through, so `float("")` raised `ValueError`
  when no `--keepthreshold` was given. Matches the existing
  `borrow_threshold` / `stop_loss_start_limit` handling.
- **`self.stop_loss_quantity` consistency**: the instance attribute
  was only assigned in the `keep_threshold` branch (via
  `update_stop_loss_quantity()`), so the "Created stop/loss order"
  notification displayed the stale init value `0.0` whenever no
  keep_threshold was used. Now assigned after both branches with the
  rounded quantity actually sent to Binance, and the
  `calculate_stop_loss_amount()` path also applies
  `round_decimals_down()` for parity with the `keep_threshold` path.
- **Fail-loud on missing balance**: `update_stop_loss_asset_amount()`
  unpacked the `get_owning_amount()` result without checking for
  `None`, which happens whenever the configured asset has no balance
  or is not listed for the account (typical for
  `binance.com-isolated_margin` if the pair was never activated, or
  on any exchange with zero balance). The bare unpack raised a
  generic `TypeError: 'NoneType' object is not iterable` deep in the
  engine thread and the streams kept running. Now fails loud with a
  clear message, dispatches email / Telegram /
  `callback_error` notifications, calls `stop_manager()` and exits,
  following the existing pattern used for `symbol_info is None`.

## Test plan

Verified end-to-end against `binance.com` with a live API key (no
testnet because the bug is path-dependent on real account data):

- [x] `ubtsl -m RENDERUSDC -n trail --stoplosslimit 1% -e binance.com`
      starts cleanly, places the `STOP_LOSS_LIMIT` order
      (`stop_loss_price=1.84`, `stop_loss_quantity=25.0` — display
      now reflects the value actually sent).
- [x] `ubtsl --exchange binance.com --market RENDERUSDC --cancelopenorders`
      cancels the order; running it again returns
      `No order was found to cancel!`.
- [x] Re-starting the engine with an existing open SL order no longer
      crashes in `get_open_orders` (regression: this was the original
      "SPOT doesn't work" symptom — caused by the dict-vs-list type
      annotation, would also have hit iso-margin/margin if an SL was
      open).
- [x] `ubtsl -m RENDERUSDC -n trail --stoplosslimit 1% -e binance.com-isolated_margin`
      on an account with **no `RENDER` balance** exits cleanly with:
      `ERROR: Asset `RENDER` not found on `binance.com-isolated_margin` - no balance or asset not listed for this account. Stopping engine.`
      (previously: silent `TypeError` in the engine thread, streams
      stayed alive).

Not covered locally: iso-margin trail **with** a real balance and an
open SL — the dict→list fix is the same code path, so the bug was
identical, but I couldn't fully verify the happy path on iso-margin
without funded balance. Worth a sanity check on a funded iso-margin
account before tagging.