### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ or the [current master branch](https://github.com/oliver-zehentleitner/unicorn-b
 - [example_logging.py](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/blob/master/example_logging.py)
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 

--- a/llms.txt
+++ b/llms.txt
@@ -104,6 +104,10 @@ ubtsl --test binance-connectivity
 - [UBWA](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) — WebSocket feed the engine trails against (can be shared via `ubwa_manager=...`).
 - [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST client for order placement (can be shared via `ubra_manager=...`).
 
+## Related Articles
+
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; positions UBTSL within the UNICORN Binance Suite landscape (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) and helps users pick the right module.
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → new `## Related Articles` section (didn't exist yet) with an LLM-oriented description

## Test plan

- [ ] Render README on GitHub and verify link position
- [ ] Open the link, confirm it resolves