### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 CLAUDE.md
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this library.
 > **This file** is for AI agents working *on* this repo itself.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
@@ -56,7 +60,7 @@ Configured via the `exchange` constructor parameter:
 
 Managed in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml` and `meta.yaml` — **all five must be kept in sync manually**, with `setup.py` as source of truth:
 
-- `unicorn-binance-websocket-api>=2.12.2` — WebSocket stream management (UBWA)
+- `unicorn-binance-websocket-api>=2.13.0` — WebSocket stream management (UBWA)
 - `unicorn-binance-rest-api>=2.2.0` — REST order placement (UBRA)
 - `requests` — HTTP
 - `Cython` — C extension compilation (release builds only)
@@ -187,4 +191,10 @@ ubtsl --test binance-connectivity
 - For `jump-in-and-trail`, the `borrow_threshold` parameter is required on margin exchanges; missing it leads to silent non-entry
 - `stop_loss_limit="2%"` vs. `"50"` semantics differ: percent is relative, bare number is an absolute price distance
 - Partially filled orders are not handled automatically — use `callback_partially_filled` if reaction is needed
-- CLI config files default to `~/.lucit/ubtsl_*.ini` (legacy path — not renamed)
+- CLI config files default to `~/.unicorn-binance-suite/config/ubtsl_*.ini` — see [`context/history.md`](context/history.md) for the `.lucit`-path migration this replaced
+- On missing balance, `update_stop_loss_asset_amount` fails loud (notifications + `stop_manager()` + exit) rather than crashing silently — see [`context/fail-loud.md`](context/fail-loud.md)
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.

--- a/context/fail-loud.md
+++ b/context/fail-loud.md
@@ -1,0 +1,17 @@
+# Fail loud on missing balance
+
+## `update_stop_loss_asset_amount` fails loud instead of crashing silently deep in the engine thread
+
+**Status:** active
+**Confirmed** (commit `862a96b`, PR #63)
+
+Found while reproducing a SPOT-exchange crash that didn't happen under `isolated_margin` — the same underlying bugs were present there too, just hidden. Root causes found and fixed together:
+- UBRA's `get_open_orders` actually returns a `list`, but Cython's strict typing enforced `Optional[dict]`
+- aggTrade price arrives as a `str`, crashing under Cython's strict float typing
+- `keep_threshold=""` slipped past an `is not None` gate
+
+The key behavioral fix: `update_stop_loss_asset_amount` now fails loud (fires `callback_error`/email/Telegram notifications, then `stop_manager()` and `sys.exit(1)`) instead of letting `total, free = None` unpack with a bare `TypeError` deep in the engine thread — which previously let the stream keep running silently after the crash.
+
+**Rejected alternative (implicit — the bug being fixed):** letting the `TypeError` propagate unhandled. That's what was happening before; the fix isn't "catch and continue," it's "catch, notify loudly through every configured channel, then stop the engine" — same fail-loud pattern already used elsewhere in this file for `symbol_info is None` (see `manager.py` ~line 1097).
+
+**Reason:** a silently-dead engine thread that still looks alive is worse than a crashed one that says so — the whole point of a trailing stop loss is that it's watching the market; a silent partial failure means it stops protecting a position without anyone knowing.

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,26 @@
+# History
+
+## LUCIT-Systems-and-Development origin, including a dropped commercial license
+
+**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Confirmed** (commit `4c14327` "Merge branch 'LUCIT-Systems-and-Development:master' into master"; commit `2d56481`)
+
+This repo once had a proprietary licensing layer: `license='LSOSL - LUCIT Synergetic Open Source License'`, with `lucit-licensing-python` as a dependency and dedicated `licensing_manager.py`/`licensing_exceptions.py`/`LucitLicensingManager` code. Commit `2d56481` ("Remove LUCIT branding, switch to MIT license, update Python support") removed the license code entirely, not just the branding — switched to plain MIT.
+
+**Reason:** LUCIT is no longer part of how this project is licensed, distributed, or supported. Unlike a pure rebrand, this one actually removed functioning licensing-check code from the package.
+
+## CI fixes from the same cleanup
+
+**Status:** active
+**Confirmed** (commits `5ef6695`, `b183472`, `759ffd3`)
+
+- CI initializes against `binance.us`, not `binance.com` — GitHub Actions runners are US-based and Binance blocks `binance.com` access from restricted (US) locations. Same reasoning as UBRA's and UBWA's unit tests.
+- `build_wheels.yml` previously only got Windows wheels to PyPI — `actions/upload-artifact@v4` stopped merging same-named artifacts across OSes silently, so Linux/Mac wheel uploads were overwritten instead of coexisting. Fixed with per-OS artifact names.
+- conda distribution switched to conda-forge; the in-repo `build_conda.yml` workflow was removed (this is why current `AGENTS.md` already only lists three workflows and explicitly notes "no in-repo conda build" — that part of `AGENTS.md` was already accurate, not stale).
+
+## Stale doc found and fixed while writing this: CLI config path
+
+**Status:** superseded — fixed in this pass
+**Confirmed** (commits `48f4450`, `0cb7324`; verified in `cli.py:47-49`)
+
+`AGENTS.md`'s "Notes & Gotchas" claimed CLI config files default to `~/.lucit/ubtsl_*.ini` ("legacy path — not renamed"). That's inaccurate: the config path was migrated to `~/.unicorn-binance-suite/config/` (commit `48f4450`), and the `.lucit` fallback path was deleted outright afterward (commit `0cb7324`, "Remove legacy .lucit path fallback — clean break") — there is no `.lucit` reference left in `cli.py`. Fixed in `AGENTS.md` alongside this history entry.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,5 @@
+# Context index
+
+- [fail-loud.md](fail-loud.md) — why `update_stop_loss_asset_amount` fails loud instead of letting a bare unpack crash silently, and the Cython strict-typing bugs found alongside it
+- [history.md](history.md) — the LUCIT-Systems-and-Development origin (including a dropped commercial-licensing layer), and the CI/build fixes that came out of the cleanup
+- [open-questions.md](open-questions.md) — two things found during this pass that aren't explained anywhere and need a maintainer answer

--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -1,0 +1,19 @@
+# Open questions
+
+Found during a retrospective pass (2026-07) — genuinely unknown, not resolved by code, commit history, or existing docs. Flagging rather than guessing (per Keep the Why rule 1).
+
+## Uncapped retry loop on Binance error `-2010`
+
+**Status:** unknown — needs maintainer input
+
+`manager.py` (~lines 573-580), inside `create_stop_loss_order`: on Binance error code `-2010`, the code does `time.sleep(5)` and loops (`while order_is_placed is False`) with no retry cap — indefinite retry on a fixed 5-second interval. Other error codes `return False` immediately instead of retrying.
+
+**Why this needs an answer:** if `-2010` ("insufficient balance" in Binance's error scheme, among other cases) can also fire for a *permanent* condition, not just a transient one, this retries forever rather than failing loud — which would be inconsistent with the fail-loud pattern documented in `fail-loud.md`. Unknown whether `-2010` is scoped narrowly enough here that infinite retry is actually safe, or whether this needs a cap.
+
+## Why `jump-in-and-trail` is margin-only
+
+**Status:** unknown — needs maintainer input
+
+The `jump-in-and-trail` engine mode is described (README, `meta.yaml`) as "still experimental, only available for Isolated Margin." Commit history for it (`d1ef241`, `6b0942e`, `acb2c88`, etc.) has only terse subject lines ("jump-in-and-trail", "integration of smart entry") with no design rationale in the commit bodies.
+
+**Why this needs an answer:** it's unclear whether spot/futures support for this mode was tried and rejected, is simply not built yet, or is scoped out for a reason specific to margin's borrow mechanics (`borrow_threshold` is required for margin — see `AGENTS.md`'s Architecture section). Worth asking directly rather than inferring from the absence of evidence.


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: context/fail-loud.md (why update_stop_loss_asset_amount fails loud on missing balance), context/history.md (LUCIT origin incl. a dropped LSOSL commercial license, CI/build fixes, a stale config-path bug found+fixed), context/open-questions.md (two things this pass couldn't explain — flagged, not guessed)
- AGENTS.md trimmed to pointers; fixed a wrong config-path claim (~/.lucit/... doesn't exist anymore, actual path is ~/.unicorn-binance-suite/config/) and a stale UBWA version floor
- README.md: Keep the Why badge
- .gitignore: AGENTS.local.md (not committed)

## Test plan
- [ ] Read through context/*.md for accuracy against actual history
- [ ] Weigh in on the two open questions (uncapped -2010 retry loop, why jump-in-and-trail is margin-only)