### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,4 +197,6 @@ ubtsl --test binance-connectivity
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/fail-loud.md
+++ b/context/fail-loud.md
@@ -3,7 +3,8 @@
 ## `update_stop_loss_asset_amount` fails loud instead of crashing silently deep in the engine thread
 
 **Status:** active
-**Confirmed** (commit `862a96b`, PR #63)
+**Evidence:** confirmed
+**Source:** commit `862a96b`, PR #63
 
 Found while reproducing a SPOT-exchange crash that didn't happen under `isolated_margin` — the same underlying bugs were present there too, just hidden. Root causes found and fixed together:
 - UBRA's `get_open_orders` actually returns a `list`, but Cython's strict typing enforced `Optional[dict]`

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## LUCIT-Systems-and-Development origin, including a dropped commercial license
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
-**Confirmed** (commit `4c14327` "Merge branch 'LUCIT-Systems-and-Development:master' into master"; commit `2d56481`)
+**Evidence:** confirmed
+**Source:** commit `4c14327` "Merge branch 'LUCIT-Systems-and-Development:master' into master"; commit `2d56481`
 
 This repo once had a proprietary licensing layer: `license='LSOSL - LUCIT Synergetic Open Source License'`, with `lucit-licensing-python` as a dependency and dedicated `licensing_manager.py`/`licensing_exceptions.py`/`LucitLicensingManager` code. Commit `2d56481` ("Remove LUCIT branding, switch to MIT license, update Python support") removed the license code entirely, not just the branding — switched to plain MIT.
 
@@ -12,7 +13,8 @@ This repo once had a proprietary licensing layer: `license='LSOSL - LUCIT Synerg
 ## CI fixes from the same cleanup
 
 **Status:** active
-**Confirmed** (commits `5ef6695`, `b183472`, `759ffd3`)
+**Evidence:** confirmed
+**Source:** commits `5ef6695`, `b183472`, `759ffd3`
 
 - CI initializes against `binance.us`, not `binance.com` — GitHub Actions runners are US-based and Binance blocks `binance.com` access from restricted (US) locations. Same reasoning as UBRA's and UBWA's unit tests.
 - `build_wheels.yml` previously only got Windows wheels to PyPI — `actions/upload-artifact@v4` stopped merging same-named artifacts across OSes silently, so Linux/Mac wheel uploads were overwritten instead of coexisting. Fixed with per-OS artifact names.
@@ -21,6 +23,7 @@ This repo once had a proprietary licensing layer: `license='LSOSL - LUCIT Synerg
 ## Stale doc found and fixed while writing this: CLI config path
 
 **Status:** superseded — fixed in this pass
-**Confirmed** (commits `48f4450`, `0cb7324`; verified in `cli.py:47-49`)
+**Evidence:** confirmed
+**Source:** commits `48f4450`, `0cb7324`; verified in `cli.py:47-49`
 
 `AGENTS.md`'s "Notes & Gotchas" claimed CLI config files default to `~/.lucit/ubtsl_*.ini` ("legacy path — not renamed"). That's inaccurate: the config path was migrated to `~/.unicorn-binance-suite/config/` (commit `48f4450`), and the `.lucit` fallback path was deleted outright afterward (commit `0cb7324`, "Remove legacy .lucit path fallback — clean break") — there is no `.lucit` reference left in `cli.py`. Fixed in `AGENTS.md` alongside this history entry.


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.